### PR TITLE
Improve quality of barcode detection

### DIFF
--- a/ios/RN/BarcodeDetectorManagerMlkit.m
+++ b/ios/RN/BarcodeDetectorManagerMlkit.m
@@ -48,7 +48,8 @@
 
 - (void)setType:(id)json queue:(dispatch_queue_t)sessionQueue 
 {
-  NSInteger requestedValue = [RCTConvert NSInteger:json];
+  // We want to set 2 types at the same time for general use
+  NSInteger requestedValue = FIRVisionBarcodeFormatEAN13 | FIRVisionBarcodeFormatEAN8;
   if (self.setOption != requestedValue) {
       if (sessionQueue) {
           dispatch_async(sessionQueue, ^{

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -1497,6 +1497,10 @@ BOOL _sessionInterrupted = NO;
 - (void)updateSessionPreset:(AVCaptureSessionPreset)preset
 {
 #if !(TARGET_IPHONE_SIMULATOR)
+    if (self.canDetectBarcodes) {
+        // Now AVCaptureSessionPresetPhoto is used for barcode detection, but it is deprecated.
+        preset = AVCaptureSessionPreset1920x1080;
+    }
     if ([preset integerValue] < 0) {
         return;
     }
@@ -1517,6 +1521,15 @@ BOOL _sessionInterrupted = NO;
             }
             else{
                 RCTLog(@"The selected preset [%@] does not work with the current session.", preset);
+                if ([self.session canSetSessionPreset:AVCaptureSessionPreset1280x720]) {
+                    [self.session beginConfiguration];
+                    self.session.sessionPreset = AVCaptureSessionPreset1280x720;
+                    [self.session commitConfiguration];
+
+                    // Need to update these since it gets reset on preset change
+                    [self updateFlashMode];
+                    [self updateZoom];
+                }
             }
         });
     }


### PR DESCRIPTION
バーコードスキャン時
・解像度をFullHDにする（Firebaseドキュメントより）
・検出フォーマットをEAN-13, EAN-8だけにする（速度向上のため）

以上を行うようにしました。

バーコードスキャン時以外に動作しなくなる可能性があります。