### PR TITLE
Fix/android slanting barcode

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -85,6 +85,6 @@ dependencies {
   implementation "androidx.exifinterface:exifinterface:1.0.0"
   implementation "androidx.annotation:annotation:1.0.0"
   implementation "androidx.legacy:legacy-support-v4:1.0.0"
-  mlkitImplementation "com.google.firebase:firebase-ml-vision:${safeExtGet('firebase-ml-vision', '19.0.3')}"
-  mlkitImplementation "com.google.firebase:firebase-ml-vision-face-model:${safeExtGet('firebase-ml-vision-face-model', '17.0.2')}"
+  mlkitImplementation 'com.google.firebase:firebase-ml-vision:24.0.1'
+  mlkitImplementation 'com.google.firebase:firebase-ml-vision-barcode-model:16.0.2'
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-camera",
   "description": "A Camera component for React Native. Also reads barcodes.",
-  "version": "3.17.0-patch-3",
+  "version": "3.17.0-patch-4",
   "author": "Lochlan Wansbrough <lochie@live.com> (http://lwansbrough.com)",
   "collective": {
     "type": "opencollective",


### PR DESCRIPTION
Androidで斜めのバーコードが認識しない件の修正。
単にAndroid版でインポートしているライブラリが古すぎるために発生していた。

※MLKitのままです