### PR TITLE
Fix/android scan performance

### DIFF
--- a/android/src/mlkit/java/org/reactnative/barcodedetector/RNBarcodeDetector.java
+++ b/android/src/mlkit/java/org/reactnative/barcodedetector/RNBarcodeDetector.java
@@ -19,10 +19,12 @@ public class RNBarcodeDetector {
     private FirebaseVisionBarcodeDetector mBarcodeDetector = null;
     private FirebaseVisionBarcodeDetectorOptions.Builder  mBuilder;
 
-    private int mBarcodeType = FirebaseVisionBarcode.FORMAT_ALL_FORMATS;
+//    private int mBarcodeType = FirebaseVisionBarcode.FORMAT_ALL_FORMATS;
 
     public RNBarcodeDetector(Context context) {
-        mBuilder = new FirebaseVisionBarcodeDetectorOptions.Builder().setBarcodeFormats(mBarcodeType);
+        // set multiple format. it cannot be done by RNCamera interface...
+        mBuilder = new FirebaseVisionBarcodeDetectorOptions.Builder()
+                .setBarcodeFormats(FirebaseVisionBarcode.FORMAT_EAN_13, FirebaseVisionBarcode.FORMAT_EAN_8);
     }
 
     public boolean isOperational() {
@@ -39,11 +41,11 @@ public class RNBarcodeDetector {
     }
 
     public void setBarcodeType(int barcodeType) {
-        if (barcodeType != mBarcodeType) {
-            release();
-            mBuilder.setBarcodeFormats(barcodeType);
-            mBarcodeType = barcodeType;
-        }
+//        if (barcodeType != mBarcodeType) {
+//            release();
+//            mBuilder.setBarcodeFormats(barcodeType);
+//            mBarcodeType = barcodeType;
+//        }
     }
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-camera",
   "description": "A Camera component for React Native. Also reads barcodes.",
-  "version": "3.17.0-patch-5",
+  "version": "3.17.0-patch-6",
   "author": "Lochlan Wansbrough <lochie@live.com> (http://lwansbrough.com)",
   "collective": {
     "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-camera",
   "description": "A Camera component for React Native. Also reads barcodes.",
-  "version": "3.17.0-patch-3",
+  "version": "3.17.0-patch-5",
   "author": "Lochlan Wansbrough <lochie@live.com> (http://lwansbrough.com)",
   "collective": {
     "type": "opencollective",


### PR DESCRIPTION
以前iOS版に対して行ったのと同様に、Androidもバーコードの種類をFANTRYで必要そうなものだけに限定した。