### PR TITLE
Fix/android scan resolution

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -1003,29 +1003,13 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
 
     @SuppressWarnings("SuspiciousNameCombination")
     private Size chooseOptimalSize(SortedSet<Size> sizes) {
-        if (!mPreview.isReady()) { // Not yet laid out
-            return sizes.first(); // Return the smallest size
-        }
-        int desiredWidth;
-        int desiredHeight;
-        final int surfaceWidth = mPreview.getWidth();
-        final int surfaceHeight = mPreview.getHeight();
-        if (isLandscape(mDisplayOrientation)) {
-            desiredWidth = surfaceHeight;
-            desiredHeight = surfaceWidth;
-        } else {
-            desiredWidth = surfaceWidth;
-            desiredHeight = surfaceHeight;
-        }
-        Size result = null;
         for (Size size : sizes) { // Iterate from small to large
-            if (desiredWidth <= size.getWidth() && desiredHeight <= size.getHeight()) {
+            // choose FHD size of preview, or biggest size
+            if (size.getWidth() * size.getHeight() >= 1080 * 1920) {
                 return size;
-
             }
-            result = size;
         }
-        return result;
+        return sizes.last();
     }
 
     private void releaseCamera() {

--- a/android/src/main/java/com/google/android/cameraview/SizeMap.java
+++ b/android/src/main/java/com/google/android/cameraview/SizeMap.java
@@ -18,6 +18,7 @@ package com.google.android.cameraview;
 
 import androidx.collection.ArrayMap;
 
+import java.util.Comparator;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -48,7 +49,12 @@ class SizeMap {
             }
         }
         // None of the existing ratio matches the provided size; add a new key
-        SortedSet<Size> sizes = new TreeSet<>();
+        SortedSet<Size> sizes = new TreeSet<>(new Comparator<Size>() {
+            @Override
+            public int compare(Size o1, Size o2) {
+                return (o1.getWidth() * o1.getHeight()) - (o2.getWidth() * o2.getHeight());
+            }
+        });
         sizes.add(size);
         mRatios.put(AspectRatio.of(size.getWidth(), size.getHeight()), sizes);
         return true;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-camera",
   "description": "A Camera component for React Native. Also reads barcodes.",
-  "version": "3.17.0-patch-7",
+  "version": "3.17.0-patch-8",
   "author": "Lochlan Wansbrough <lochie@live.com> (http://lwansbrough.com)",
   "collective": {
     "type": "opencollective",


### PR DESCRIPTION
Androidのバーコードスキャンの精度を上げるためにカメラ出力映像の解像度をFullHDに近づける対応を行った。

Camera API 2を使ったほうが高い解像度を選ぶことができるが、未完成だったためCamera API 1で選択できる範囲でより高い解像度を選ぶだけとした。