### PR TITLE
Fix/support barcode types

### DIFF
--- a/ios/RN/BarcodeDetectorManagerMlkit.h
+++ b/ios/RN/BarcodeDetectorManagerMlkit.h
@@ -10,7 +10,6 @@ typedef void(^postRecognitionBlock)(NSArray *barcodes);
 - (instancetype)init;
 
 -(BOOL)isRealDetector;
--(void)setType:(id)json queue:(dispatch_queue_t)sessionQueue;
 -(void)findBarcodesInFrame:(UIImage *)image scaleX:(float)scaleX scaleY:(float)scaleY completed:(postRecognitionBlock)completed;
 +(NSDictionary *)constants;
 

--- a/ios/RN/BarcodeDetectorManagerMlkit.m
+++ b/ios/RN/BarcodeDetectorManagerMlkit.m
@@ -16,7 +16,11 @@
 {
   if (self = [super init]) {
     self.vision = [FIRVision vision];
-    self.barcodeRecognizer = [_vision barcodeDetector];
+    // it can read only EAN-13 and EAN-8 bacodes
+    self.setOption = FIRVisionBarcodeFormatEAN13 | FIRVisionBarcodeFormatEAN8;
+    FIRVisionBarcodeDetectorOptions *options =
+        [[FIRVisionBarcodeDetectorOptions alloc] initWithFormats: self.setOption];
+    self.barcodeRecognizer = [self.vision barcodeDetectorWithOptions:options];
   }
   return self;
 }
@@ -44,24 +48,6 @@
                 @"DATA_MATRIX" : @(FIRVisionBarcodeFormatDataMatrix),
                 @"ALL" : @(FIRVisionBarcodeFormatAll),
             };
-}
-
-- (void)setType:(id)json queue:(dispatch_queue_t)sessionQueue 
-{
-  // We want to set 2 types at the same time for general use
-  NSInteger requestedValue = FIRVisionBarcodeFormatEAN13 | FIRVisionBarcodeFormatEAN8;
-  if (self.setOption != requestedValue) {
-      if (sessionQueue) {
-          dispatch_async(sessionQueue, ^{
-              self.setOption = requestedValue;
-              FIRVisionBarcodeDetectorOptions *options =
-              [[FIRVisionBarcodeDetectorOptions alloc]
-              initWithFormats: requestedValue];
-              self.barcodeRecognizer =
-              [self.vision barcodeDetectorWithOptions:options];
-          });
-      }
-  }
 }
 
 - (void)findBarcodesInFrame:(UIImage *)uiImage

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -2109,7 +2109,6 @@ BOOL _sessionInterrupted = NO;
 
 - (void)updateGoogleVisionBarcodeType:(id)requestedTypes
 {
-    [self.barcodeDetector setType:requestedTypes queue:self.sessionQueue];
 }
 
 - (void)onBarcodesDetected:(NSDictionary *)event

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-camera",
   "description": "A Camera component for React Native. Also reads barcodes.",
-  "version": "3.19.0-9",
+  "version": "3.19.0-10",
   "author": "Lochlan Wansbrough <lochie@live.com> (http://lwansbrough.com)",
   "collective": {
     "type": "opencollective",


### PR DESCRIPTION
iOS版で読み取るバーコードの種別を指定する処理が呼ばれなくなっていたため、必ず呼ばれるように修正。

また、FANTRY案件ではバーコードの種類を動的に変更したりしないため、使われなくなっていたセッター関数を削除

※Android版については、既にiOS版の修正後相当のコードになっており、正常動作していたため未変更です