### PR TITLE
Send rawBytes of native's barcode object to javascript

### DIFF
--- a/android/src/mlkit/java/org/reactnative/camera/tasks/BarcodeDetectorAsyncTask.java
+++ b/android/src/mlkit/java/org/reactnative/camera/tasks/BarcodeDetectorAsyncTask.java
@@ -2,6 +2,7 @@ package org.reactnative.camera.tasks;
 
 //import android.graphics.Point;
 import android.graphics.Rect;
+import android.util.Base64;
 import android.util.Log;
 
 import com.facebook.react.bridge.Arguments;
@@ -278,6 +279,7 @@ public class BarcodeDetectorAsyncTask extends android.os.AsyncTask<Void, Void, V
 
       serializedBarcode.putString("data", barcode.getDisplayValue());
       serializedBarcode.putString("dataRaw", rawValue);
+      serializedBarcode.putString("dataRawBytesBase64", Base64.encodeToString(barcode.getRawBytes(), Base64.DEFAULT));
       serializedBarcode.putString("type", BarcodeFormatUtils.get(valueType));
       serializedBarcode.putString("format", BarcodeFormatUtils.getFormat(valueFormat));
       serializedBarcode.putMap("bounds", processBounds(bounds));

--- a/ios/RN/BarcodeDetectorManagerMlkit.m
+++ b/ios/RN/BarcodeDetectorManagerMlkit.m
@@ -86,6 +86,7 @@
         NSString *displayValue = barcode.displayValue;
         [resultDict setObject:rawValue forKey:@"dataRaw"];
         [resultDict setObject:displayValue forKey:@"data"];
+        [resultDict setObject:[barcode.rawData base64EncodedStringWithOptions:0] forKey:@"dataRawBytesBase64"];
         
         FIRVisionBarcodeValueType valueType = barcode.valueType;
         [resultDict setObject:[self getType:barcode.valueType] forKey:@"type"];

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-camera",
   "description": "A Camera component for React Native. Also reads barcodes.",
-  "version": "3.19.0-11",
+  "version": "3.19.0-12",
   "author": "Lochlan Wansbrough <lochie@live.com> (http://lwansbrough.com)",
   "collective": {
     "type": "opencollective",

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -139,6 +139,7 @@ type TrackedBarcodeFeature = {
   },
   data: string,
   dataRaw: string,
+  dataRawBytesBase64: string,
   type: BarcodeType,
   format?: string,
   addresses?: {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -259,6 +259,7 @@ export interface Barcode {
   };
   data: string;
   dataRaw: string;
+  dataRawBytesBase64: string;
   type: BarcodeType;
   format?: string;
   addresses?: {


### PR DESCRIPTION
RNCameraの現状の実装だと、QRコードから取り出したbyte配列をJS側で使用するすべがなかったため、Interfaceを拡張。
ただしByteArrayをそのままやり取りできないため、Base64に変換する処理を挟んでいる。